### PR TITLE
AsciiTable doesn't support cells with 'bytes' values so we need to convert them to 'str'

### DIFF
--- a/testplan/testing/multitest/entries/stdout/base.py
+++ b/testplan/testing/multitest/entries/stdout/base.py
@@ -125,6 +125,12 @@ class DirectoryRenderer(BaseRenderer):
 @registry.bind(base.TableLog)
 class TableLogRenderer(BaseRenderer):
     def get_details(self, entry):
+        # AsciiTable doesn't support cells with 'bytes' values so we need to convert them to 'str'
+        for j, row in enumerate(entry.table):
+            for i, cell in enumerate(row):
+                if isinstance(cell, bytes):
+                    entry.table[j][i] = str(cell)
+
         return AsciiTable([entry.columns] + entry.table).table
 
 


### PR DESCRIPTION
## Bug / Requirement Description
AsciiTable doesn't support cells with 'bytes' values

## Solution description
Convert 'bytes' values to 'str' before we pass them to AsciiTable

## Checklist:
- [ ] Test
- [ ] Example (both test_plan.py and .rst)
- [ ] Documentation (API)
- [ ] News fragment present for release notes
- [ ] MS info leakage check
- [ ] For new driver: driver index page
- [ ] For new assertion: ui/pdf/std renderers, documentation
- [ ] For new cmdline arg: documentation
